### PR TITLE
Add final tests

### DIFF
--- a/translator-service/tests/test.py
+++ b/translator-service/tests/test.py
@@ -4,7 +4,7 @@ from translator.util import supported_languages
 import multiprocessing
 from bson.objectid import ObjectId
 import time
-from translator import mlfunctions, mlworker
+from translator import mlfunctions, mlworker, jobhandler, create_app
 from transformers import M2M100ForConditionalGeneration, M2M100Tokenizer
 
 ckpt = 'facebook/m2m100_418M'
@@ -32,12 +32,12 @@ def test_translate_unsupported_language(model_tr, tokenizers):
         mlfunctions.translate("hello", "xyz", model_tr, tokenizers)
 
 @pytest.fixture
-def test_db():
-    # Set up a test database for the duration of the test
-    # You may need to modify this to create a new database or collection specifically for the test
-    db = mongomock.MongoClient('mongodb://localhost:27017')
-    yield db.translator.translations
-    # Clean up any changes made to the test database
+def mongo_client():
+    yield mongomock.MongoClient('mongodb://localhost:27017')
+
+@pytest.fixture
+def test_db(mongo_client):
+    yield mongo_client.translator.translations
 
 @pytest.fixture
 def model_tr():
@@ -51,6 +51,14 @@ def tokenizers():
 def job_queue():
     queue = multiprocessing.Queue()
     yield queue
+
+def test_app(mongo_client):
+    app = create_app({
+        "TESTING": True,
+        "MONGO_CLIENT": mongo_client,
+        "NUM_THREADS": 2
+    })
+    assert app != None
 
 @pytest.mark.parametrize("lang,expected_output", [
     ('arabic', "Assalam Alaikum"),
@@ -104,3 +112,9 @@ def test_work(lang, expected_output, test_db, job_queue):
 #     assert "IN_QUEUE" in response.body
 #     assert "None" in response.body
 
+@pytest.mark.parametrize("threads", [(1),(2),(3),(4)])
+def test_job_handler(threads, test_db, job_queue):
+    processes = jobhandler.start_threads(threads, test_db, job_queue)
+    assert len(processes) == threads
+    for process in processes:
+        process.kill()

--- a/translator-service/translator/jobhandler.py
+++ b/translator-service/translator/jobhandler.py
@@ -21,6 +21,12 @@ def start_threads(num_threads, db, slowstart=False):
     # Compute a delay amount between threads starting to ensure even spacing.
     delay = 30 if slowstart else 1.0/float(num_threads)
 
+    processes = []
+
     # Create and start the number of threads requested.
     for i in range(num_threads):
-        multiprocessing.Process(target=work, args=(i, job_queue, i*delay, db, -1)).start()
+        process = multiprocessing.Process(target=work, args=(i, job_queue, i*delay, db, -1))
+        process.start()
+        processes.append(process)
+
+    return processes


### PR DESCRIPTION
These tests get the coverage for the ML part up to 80%, including tests.py. However, one of these tests is testing the app creation function. This test requires MongoDB to be running in the background and will require a Ctrl+C to end after the results are pushed. Then the coverage will be printed.

I used this command to run:
```
coverage run -m pytest ./tests/test.py && python -m coverage report
```

If someone else has the time and energy to make more tests to increase the coverage more, or to reduce the need for the weird hacky workarounds for the `test_app()` test, that would be awesome. But unfortunately, I have neither the time nor the energy to continue working on this. So I'm releasing this PR. Feel free to add to this same branch, if that's easiest.